### PR TITLE
Updated tool to work for 3.2.15 LTS and later

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # VS Code settings ignored
+*.code-workspace
 .vscode/
 
 # misc Mac OS X.

--- a/GeneratorTemplates/Readme.md
+++ b/GeneratorTemplates/Readme.md
@@ -1,9 +1,19 @@
-# Generated Django Single-Page Application with User Account support.
+# Auto-generated Django Single-Page Application Scaffold.
 
-This is a generated tool. Please update accordingly for actual tool development.
+This is a generated tool. It assumes default basic (optional) support for:
+1. User accounts and authentication (see auto-generated accounts app.)
+1. Django REST framework for web interaction with the installed database.
+1. SQLite database. Users are advised to replace this with a production database if needed.
 
-## Next Steps
+Please update accordingly for actual tool development.
 
-1. Clean up appended structures in the project's settings.py file.
-1. Clean up appended structures in the project's urls.py file.
-1. Clean up appended structures in the accounts app's views.py file.
+## Next Development Steps
+
+Tool developers can use the comments marked "TODO" in the appropriate
+default Django files updated by the scaffolding tool. There are also files created by
+the scaffolding tool.
+
+1. Update or clean appended structures in the project's settings.py file.
+1. Update or clean appended structures in the project's urls.py file.
+1. Update or clean appended structures in the accounts app's views.py file.
+1. Review and clean constructs in the newly-created urls.py file in the accounts app.

--- a/GeneratorTemplates/fragments/general_settings
+++ b/GeneratorTemplates/fragments/general_settings
@@ -1,4 +1,9 @@
+# DEBUG is expected to be set to true in an initial Django setup.
 
+
+# TODO: Tool developers can add their own apps here.
+# TODO: Tool developers can merge this variable with the default
+#   once they are satisfied things work as intended.
 INSTALLED_APPS += [
     # Third Party
     'rest_framework',
@@ -6,17 +11,19 @@ INSTALLED_APPS += [
     'accounts',
 ]
 
-TEMPLATES[0]['DIRS'] = [os.path.join(BASE_DIR, "templates")]
+# NOTE: In 3.2.15 LTS, Django has stopped using os.path (see our 
+#   2.2.16 LTS implementation for the differences.) 
+TEMPLATES[0]['DIRS'] = [ BASE_DIR / 'templates' ]
 
-# Development Only - serve static content from the Simulated server
+# Development Only - serve static content from a simulated server.
 if DEBUG:
     STATIC_URL = 'static/'
 
 # Specify default locations of static content for collectstatic.
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "static"),
+    BASE_DIR / 'static'
 ]
-STATIC_ROOT = os.path.join(BASE_DIR, "static-root")
+STATIC_ROOT = BASE_DIR / 'static-root'
 
 # REST Framework Default Authenticator and Renderers
 

--- a/GeneratorTemplates/fragments/general_urls
+++ b/GeneratorTemplates/fragments/general_urls
@@ -1,17 +1,26 @@
-
+# TODO: The tool developers may wish to merge the include
+#    import from django.urls with the default import line
+#    for django.urls.
 from django.urls import include 
-from accounts.views import home_view
-
 from django.conf import settings
 from django.conf.urls.static import static
 
-# Overwrite instead of append, because we need the order to be correct.
+from accounts.views import home_view
+
+# We override the default urlpatterns variable instead of appending to it, 
+#   because we need the order of path resolution to be correct.
+#
+# TODO: The tool developers can and should merge the two after they are
+#   satisfied that things work as intended.
 urlpatterns = [
     path('', home_view),
     path('admin/', admin.site.urls),
     path('accounts/', include('accounts.urls')),
 ]
 
-# Development only - Simulated Static folder
+# For development use only - linkage to a local static folder.
+#
+# TODO: In production static content should be served from a proper host server,
+#   even if that server is local.
 if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/GeneratorTemplates/gitignore_template
+++ b/GeneratorTemplates/gitignore_template
@@ -9,6 +9,7 @@ __pycache__/
 static-root/
 
 # VS Code settings ignored
+*.code-workspace
 .vscode/
 
 # misc Mac OS X.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Coding For Entrepreneurs.
 
 * Python >=3.9
 * Pipenv >=2020.8.13
-* Django == 2.2.16 (LTS)
+* Django == 3.2.15 (LTS)
 
 ## Getting Started
 

--- a/setup.sh
+++ b/setup.sh
@@ -25,25 +25,33 @@ if [ $? -ne 0 ]; then
     exit -1
 fi 
 
-pipenv install django==2.2.16
+# Use pipenv to set up the essential Python packages
+pipenv install django==3.2.15
+pipenv install djangorestframework
+
+# Set up the basic standard Django structure with a default app for managing accounts.
 pipenv run django-admin startproject $project .
+pipenv run python manage.py startapp accounts
+
+# Populate newly created structure with frontend scaffold
 cp -R $template_root/static ./static
 cp -R $template_root/templates ./templates
 cp -R $template_root/rest_api $project/
 cp $template_root/gitignore_template .gitignore
 cp $template_root/Readme.md .
 
-pipenv run python manage.py startapp accounts
-cat $template_root/fragments/accounts_urls >> accounts/urls.py
+# Modify and populate backend structures with appropriate links to the frontend scaffold.
 cat $template_root/fragments/accounts_views >> accounts/views.py
+cat $template_root/fragments/accounts_urls >> accounts/urls.py
 cat $template_root/fragments/general_urls >> $project/urls.py
 
-pipenv install djangorestframework
 cat $template_root/fragments/general_settings | sed "s/__MYPROJECT__/$project/g" >> $project/settings.py
 mkdir static-root
 
+# Create and populate default sqlite database.
 pipenv run python manage.py migrate
-# If User Authentication Sub-system requested.
+
+# Default User Authentication Sub-system tied to the accounts app.
 # User will be prompted for name, email, and password
 pipenv run python manage.py createsuperuser
 pipenv run python manage.py collectstatic


### PR DESCRIPTION
Updated the framework for use with Django 3.2.15 LTS (supported until 2024.)

The primary change is the use of pathlib instead of os.path in settings.py.
The order of script commands have also been altered to better reflect dependency and structure especially if errors occur. Note that errors are still not explicitly handled in this version.
Finally the README documents have also been updated to better guide tool developers using this scaffolding tool to get started with their Django projects. These updates were driven by my own need to use this tool on new projects in a more professional environment. 

I expect to further update this repository once Django 4.2.x (LTS) is released.